### PR TITLE
Fixed typo in MyStack.java example

### DIFF
--- a/doc_source/hello_world_tutorial.md
+++ b/doc_source/hello_world_tutorial.md
@@ -193,7 +193,7 @@ import software.amazon.awscdk.services.s3.Bucket;
 import software.amazon.awscdk.services.s3.BucketProps;
 
 public class MyStack extends Stack {
-    public MyStack(final App scopy, final String id) {
+    public MyStack(final App scope, final String id) {
         this(scope, id, null);
     }
 


### PR DESCRIPTION
In the first constructor for MyStack, the variable scope was typo-ed to 'scopy'.

*Issue #, if available:*
N/A

*Description of changes:*
Fixing a typo in the Java example of the CDK MyStack. No change was made in the documentation sentence "In some cases this command fails, such as when a resource isn't empty and must be empty before it can be destroyed\. See [Delete Stack Fails](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/troubleshooting.html#troubleshooting-errors-delete-stack-fails) in the *AWS CloudFormation User Guide* for details\.", but GitHub believes a change was made.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
