### PR TITLE
Add the way to pass context with cdk.context.json

### DIFF
--- a/doc_source/get_context_var.md
+++ b/doc_source/get_context_var.md
@@ -24,6 +24,14 @@ To specify the same context variable and value in the `cdk.json` file, use the f
 }
 ```
 
+To specify the same context variable and value in the `cdk.context.json` file, use the following code\.
+```
+{
+  "bucket_name": "myotherbucket"
+}
+```
+
+
 To get the value of a context variable in your app, use code like the following, which gets the value of the context variable **bucket\_name**\.
 
 ```


### PR DESCRIPTION
*Description of changes:*
- When I set context according to [get_context_var section] (https://docs.aws.amazon.com/CDK/latest/userguide/get_context_var.html), unexpected context was set.
- [document screen shot](https://gyazo.com/5f5c64b74a15af154d3996b3c5a8ddc1) and [result screen shot](https://gyazo.com/52e47088e33cd260523791cf76e181b3)
- It seems that hosted html and html on this repo differ.But anyway I think, right way to set context in `cdk.context.json` should be written.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
