### PR TITLE
TypeScript import typo

### DIFF
--- a/doc_source/multiple_languages.md
+++ b/doc_source/multiple_languages.md
@@ -15,7 +15,7 @@ The CDK supports C\#, Java, JavaScript, and TypeScript\. Since the CDK is develo
 In TypeScript, you import a package as follows \(we'll use Amazon S3 for our examples\):
 
 ```
-import lambda = require("@aws-cdk/aws-s3");
+import s3 = require("@aws-cdk/aws-s3");
 ```
 
 ------


### PR DESCRIPTION
Fix typo in TypeScript import on page `doc_source/multiple_languages.md`.