### PR TITLE
Update ECS Fargate example

### DIFF
--- a/doc_source/ecs_example.md
+++ b/doc_source/ecs_example.md
@@ -90,7 +90,7 @@ Replace the comment at the end of the constructor with the following code\.
     });
 
     // Create a load-balanced Fargate service and make it public
-    new ecs_patterns.LoadBalancedFargateService(this, "MyFargateService", {
+    new ecs_patterns.ApplicationLoadBalancedFargateService(this, "MyFargateService", {
       cluster: cluster, // Required
       cpu: 512, // Default is 256
       desiredCount: 6, // Default is 1


### PR DESCRIPTION
Updating example to use ApplicationLoadBalancedFargateService instead of LoadBalancedFargateService as it's deprecated

Fixes issue #120 

Description of changes: example would break on brand new install of latest CDK version. Updating to ApplicationLoadBalancedFargateService deployed successfully.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
