### PR TITLE
Update codepipeline_example.md

### DIFF
--- a/doc_source/codepipeline_example.md
+++ b/doc_source/codepipeline_example.md
@@ -338,7 +338,7 @@ export class PipelineStack extends Stack {
         },
       }),
       environment: {
-        buildImage: codebuild.LinuxBuildImage.UBUNTU_14_04_NODEJS_10_14_1,
+        buildImage: LinuxBuildImage.STANDARD_2_0,
       },
     });
     const lambdaBuild = new codebuild.PipelineProject(this, 'LambdaBuild', {
@@ -364,7 +364,7 @@ export class PipelineStack extends Stack {
         },
       }),
       environment: {
-        buildImage: codebuild.LinuxBuildImage.UBUNTU_14_04_NODEJS_10_14_1,
+        buildImage: LinuxBuildImage.STANDARD_2_0,
       },
     });
 


### PR DESCRIPTION
The UBUNTU build images are deprecated in favor of the STANDARD_X_X images.

*Description of changes:*
Updated documentation to reflect the deprecated, as outlined here:
https://github.com/aws/aws-cdk/blob/master/packages/%40aws-cdk/aws-codebuild/lib/project.ts#L1207


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
