### PR TITLE
Fix typo for Python in multistack

### DIFF
--- a/doc_source/stack_how_to_create_multiple_stacks.md
+++ b/doc_source/stack_how_to_create_multiple_stacks.md
@@ -271,7 +271,7 @@ class MultistackStack(core.Stack):
         # Encrypted bucket uses AWS KMS-managed keys (SSE-KMS).
         if encrypt_bucket:
             s3.Bucket(self, "MyGroovyBucket",
-                      encryption=s3BucketEncryption.KMS_MANAGED,
+                      encryption=s3.BucketEncryption.KMS_MANAGED,
                       removal_policy=core.RemovalPolicy.DESTROY)
         else:
             s3.Bucket(self, "MyGroovyBucket",


### PR DESCRIPTION
Fix typo in stack_how_to_create_multiple_stacks.md for python examples

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
