### PR TITLE
cdk bootstrap options display

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ so the community can see, comment, and contribute.
 > :memo: **NOTE** -
 > The Markdown files in this repository are an *output* of the AWS CDK Developer Guide build process, not the actual source files. 
 Periodically, we update the Markdown files here from our builds. This means that changes may appear on docs.aws.amazon.com before they appear
-here. Also, sometimes we may close a PR instead of merging it, even if we have in fact integrated your submission into the Guide.
+here.
 
 ## Other Documentation Issues
 

--- a/doc_source/tools.md
+++ b/doc_source/tools.md
@@ -111,8 +111,9 @@ cdk list [STACKS..]
 Lists all stacks in the app
 
 Options:
-  --long, -l            Display environment information for each stack
-                                                      [boolean] [default: false]
+  --long, -l            
+  Display environment information for each stack
+  [boolean] [default: false]
 ```
 
 #### `cdk synthesize` \(`synth`\)<a name="cli-synth"></a>
@@ -123,8 +124,9 @@ cdk synthesize [STACKS..]
 Synthesizes and prints the CloudFormation template for this stack
 
 Options:
-  --exclusively, -e     Only synthesize requested stacks, don't include
-                        dependencies                                   [boolean]
+  --exclusively, -e     
+  Only synthesize requested stacks, don't include dependencies                                   
+  [boolean]
 ```
 
 If your app has a single stack, you don't have to specify the stack name\.
@@ -137,15 +139,21 @@ cdk bootstrap [ENVIRONMENTS..]
 Deploys the CDK toolkit stack into an AWS environment
 
 Options:
-  --bootstrap-bucket-name, -b,              The name of the CDK toolkit bucket
-  --toolkit-bucket-name                                                 [string]
-  --bootstrap-kms-key-id                    AWS KMS master key ID used for the
-                                            SSE-KMS encryption          [string]
-  --tags, -t                                Tags to add for the stack
-                                            (KEY=VALUE)    [array] [default: []]
-  --execute                                 Whether to execute ChangeSet
-                                            (--no-execute will NOT execute the
-                                            ChangeSet) [boolean] [default: true]
+  --bootstrap-bucket-name, -b, --toolkit-bucket-name
+  The name of the CDK toolkit bucket that bootstrap creates for you.
+  [string]
+  
+  --bootstrap-kms-key-id                    
+  AWS KMS master key ID used for the SSE-KMS encryption          
+  [string]
+  
+  --tags, -t                                
+  Tags to add for the stack
+  (KEY=VALUE)    [array] [default: []]
+  
+  --execute                                 
+  Whether to execute ChangeSet (--no-execute will NOT execute the ChangeSet) 
+  [boolean] [default: true]
 ```
 
 #### `cdk deploy`<a name="cli-deploy"></a>


### PR DESCRIPTION
Changed the way the cdk bootstrap options where displayed as having --toolkit-bucket-name on the next line was creating customer confusion, i.e. customer thought that --bootstrap-bucket-name and --toolkit-bucket-name were 2 different bucket and since "[string]" was on the same line as --toolkit-bucket-name, they took this as the only explanation if what the parameter meant so they had no idea what this was for.

If this display method is not accepted, alternatively use tables to display these options

Further, customer needs docs to be more clearer on whether bootstrap creates the bucket.

Please include documentation on what security is added to the bucket when boostrap creates it as well as if any life cycle is applied.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
