### PR TITLE
fix wrong date and order of document history

### DIFF
--- a/doc_source/doc-history.md
+++ b/doc_source/doc-history.md
@@ -11,10 +11,10 @@ The table below represents significant milestones\. We fix errors and improve co
 
 | Change | Description | Date | 
 | --- |--- |--- |
+| [Version 1\.21\.0](#doc-history) | Add "Working with the CDK" articles for the five supported languages\. Various other improvements and fixes\. | February 4, 2020 | 
 | [Version 1\.18\.0](#doc-history) | Add Java code snippets throughout\. Designate Java and C\# bindings stable\. | November 25, 2019 | 
 | [Version 1\.17\.0](#doc-history) | Add C\# code snippets throughout\. | November 19, 2019 | 
 | [Version 1\.16\.0](#doc-history) | Add Python code snippets throughout\. Add Troubleshooting and Testing topics\. | November 14, 2019 | 
 | [Version 1\.8\.0](#doc-history) | Updates to reflect improvements to ECS Patterns module\. | September 17, 2019 | 
 | [Version 1\.3\.0](#doc-history) | Update tagging topic to use new API\. | August 13, 2019 | 
 | [Version 1\.0\.0](#doc-history) | The AWS CDK Developer Guide is released\. | July 11, 2019 | 
-| [Version 1\.21\.0](#doc-history) | Add "Working with the CDK" articles for the five supported languages\. Various other improvements and fixes\. | February 4, 2019 | 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
- Update the date of the document ver 1.21 from `February 4, 2019` to `February 4, 2020`
- Change the order of the items in the history table

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
