### PR TITLE
"Construct" constructor does not accept "props" argument

### DIFF
--- a/doc_source/constructs.md
+++ b/doc_source/constructs.md
@@ -847,7 +847,7 @@ export class NotifyingBucket extends Construct {
 class NotifyingBucket extends Construct {
 
   constructor(scope, id, props) {
-    super(scope, id, props);
+    super(scope, id);
     const bucket = new s3.Bucket(this, 'bucket');
     this.topic = new sns.Topic(this, 'topic');
     bucket.addObjectCreatedNotification(this.topic, { prefix: props.prefix });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Noticed this when reading the docs. I'm on CDK 1.49.1 and the `Construct` constructor does not accept a `props` argument.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
