### PR TITLE
Adds AWS RFDK to version reporting section

### DIFF
--- a/doc_source/cli.md
+++ b/doc_source/cli.md
@@ -57,6 +57,7 @@ By default, the AWS CDK reports the name and version of the following NPM module
 + AWS CDK core module
 + AWS Construct Library modules
 + AWS Solutions Constructs module
++ AWS Render Farm Deployment Kit module
 
 The `AWS::CDK::Metadata` resource looks something like the following\.
 
@@ -64,7 +65,7 @@ The `AWS::CDK::Metadata` resource looks something like the following\.
 CDKMetadata:
   Type: "AWS::CDK::Metadata"
   Properties:
-    Modules: "@aws-cdk/core=X.YY.Z,@aws-cdk/s3=X.YY.Z,@aws-solutions-consturcts/aws-apigateway-lambda=X.YY.Z"
+    Modules: "@aws-cdk/core=X.YY.Z,@aws-cdk/s3=X.YY.Z,@aws-solutions-consturcts/aws-apigateway-lambda=X.YY.Z,aws-rfdk=X.YY.Z"
 ```
 
 To opt out of version reporting, use one of the following methods:


### PR DESCRIPTION
The AWS RFDK is a product that is being released shortly, and we are adding tracking of its usage to the CDK's version reporting metadata.

*Description of changes:* Once https://github.com/aws/aws-cdk/pull/9337 is merged, the CDK will also be version tracking the aws-rfdk package. This adds it to the list of packages being version reported.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
