### PR TITLE
Fixed Missing line in Java example

### DIFF
--- a/doc_source/serverless_example.md
+++ b/doc_source/serverless_example.md
@@ -811,6 +811,8 @@ File: `my_widget_service/widget_service.py`
 File: `src/src/main/java/com/myorg/WidgetService.java`
 
 ```
+        Resource widget = api.getRoot().addResource("{id}");
+        
         // Add new widget to bucket with: POST /{id}
         LambdaIntegration postWidgetIntegration = new LambdaIntegration(handler);
 


### PR DESCRIPTION
Added a line for defining the widget in the Java example. :-)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
