### PR TITLE
Remove semicolons from python examples

### DIFF
--- a/doc_source/context.md
+++ b/doc_source/context.md
@@ -184,10 +184,10 @@ class ExistsVpcStack(cdk.Stack):
   
         super().__init__(scope, id, **kwargs)
     
-        vpcid = self.node.try_get_context("vpcid");
+        vpcid = self.node.try_get_context("vpcid")
         vpc = ec2.Vpc.from_lookup(self, "VPC", vpc_id=vpcid)
     
-        pubsubnets = vpc.select_subnets(subnetType=ec2.SubnetType.PUBLIC);
+        pubsubnets = vpc.select_subnets(subnetType=ec2.SubnetType.PUBLIC)
     
         cdk.CfnOutput(self, "publicsubnets",
             value=pubsubnets.subnet_ids.to_string())


### PR DESCRIPTION
*Description of changes:* Removed 2 semicolons from a python example on the context page


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
