### PR TITLE
Fix Python example in How to Create CDK Pipeline guide

### DIFF
--- a/doc_source/cdk_pipeline.md
+++ b/doc_source/cdk_pipeline.md
@@ -1142,10 +1142,10 @@ testingStage.addApplication(new MyApplication2(this, 'MyApp2', {
 
 ```
 # Add two application stages to the same pipeline stage
-testing_stage.add_application(MyApplication1(this, 'MyApp1',
+testing_stage.add_application_stage(MyApplication1(this, 'MyApp1',
     env=Environment(account="111111111111", region="eu-west-1")))
 
-testing_stage.add_application(MyApplication2(this, 'MyApp2', 
+testing_stage.add_application_stage(MyApplication2(this, 'MyApp2', 
     env=Environment(account="111111111111", region="eu-west-1")))
 ```
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Fix Python example of adding more than one application stage to a pipeline stage. Correct method is `add_application_stage()`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
