### PR TITLE
Fix incorrect import for RemovalPolicy

### DIFF
--- a/doc_source/hello_world.md
+++ b/doc_source/hello_world.md
@@ -432,7 +432,7 @@ bucket = s3.Bucket(self, "MyFirstBucket",
 Update `src/main/java/com/myorg/HelloCdkStack.java`, adding the new import and updating the bucket definition in the appropriate places\.
 
 ```
-import software.amazon.awscdk.services.s3.BucketEncryption;
+import software.amazon.awscdk.core.RemovalPolicy;
 ```
 
 ```


### PR DESCRIPTION
In the example showing how to specify a RemovalPolicy the incorrect import was being specified:

```java
import software.amazon.awscdk.core.RemovalPolicy;
```

instead of 

```java
import software.amazon.awscdk.services.s3.BucketEncryption;
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
