### PR TITLE
SecretArn is deprecated in latest C# CDK version

### DIFF
--- a/doc_source/get_secrets_manager_value.md
+++ b/doc_source/get_secrets_manager_value.md
@@ -94,7 +94,7 @@ public class SecretsManagerStack : Stack
     public SecretsManagerStack(App scope, string id, StackProps props) : base(scope, id, props) {
 
         var secret = Secret.FromSecretAttributes(this, "ImportedSecret", new SecretAttributes {
-            SecretArn = "arn:aws:secretsmanager:<region>:<account-id-number>:secret:<secret-name>-<random-6-characters>"
+            SecretCompleteArn = "arn:aws:secretsmanager:<region>:<account-id-number>:secret:<secret-name>-<random-6-characters>"
             // If the secret is encrypted using a KMS-hosted CMK, either import or reference that key:
             // encryptionKey = ...,
         });


### PR DESCRIPTION
*Description of changes:*
In the latest version of CDK for C#, SecretArn is deprecated. Replacing SecretArn with SecretCompleteArn to follow latest version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
