### PR TITLE
Comma added to install_requires

### DIFF
--- a/doc_source/work-with-cdk-v2.md
+++ b/doc_source/work-with-cdk-v2.md
@@ -135,7 +135,7 @@ install_requires=[
      "aws-cdk-lib>=2.0.0rc1",
      "constructs>=10.0.0",
      # ...
-]
+],
 ```
 
 Install the new dependencies with `pip install -r requirements.txt`\.


### PR DESCRIPTION
A Comma needed to be added to the end of the install_requires list. This allows for easy copy/pasting

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
