### PR TITLE
Resolving Windows file encoding issues

### DIFF
--- a/doc_source/bootstrapping.md
+++ b/doc_source/bootstrapping.md
@@ -78,7 +78,7 @@ cdk bootstrap --show-template > bootstrap-template.yaml
 #### [ Windows ]
 
 ```
-cdk bootstrap --show-template | Out-File -encoding utf8 bootstrap-template.yaml
+powershell "cdk bootstrap --show-template | Out-File -encoding utf8 bootstrap-template.yaml"
 ```
 
 ------

--- a/doc_source/bootstrapping.md
+++ b/doc_source/bootstrapping.md
@@ -67,9 +67,21 @@ cdk bootstrap --profile prod
 
 AWS CDK bootstrapping is performed by an AWS CloudFormation template\. To get a copy of this template in the file `bootstrap-template.yaml`, run the following command\.
 
+------
+#### [ macOS/Linux ]
+
 ```
 cdk bootstrap --show-template > bootstrap-template.yaml
 ```
+
+------
+#### [ Windows ]
+
+```
+cdk bootstrap --show-template | Out-File -encoding utf8 bootstrap-template.yaml
+```
+
+------
 
 The template is also available in the [AWS CDK GitHub repository](https://github.com/aws/aws-cdk/blob/master/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml)\.
 


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-cdk/issues/15066

*Description of changes:*

Windows `>` redirect operator (an alias for the PowerShell cmdlet 'Out-File') defaults to UTF-16LE encoding as per [the documentation.](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_character_encoding?view=powershell-7.1#character-encoding-in-windows-powershell)

The CDK expects templates fed to it with the `--template` CLI flag to be UTF-8 encoded, so grabbing the template according to the current docs will technically download the template file but prevent you from doing anything further with it using the CDK.

Proposing we add separation for Mac/Linux and Windows so that we can explicitly enforce utf-8 encoding for the Windows Out-File cmdlet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
