### PR TITLE
Fix typo in NuGet package name

### DIFF
--- a/doc_source/ecs_example.md
+++ b/doc_source/ecs_example.md
@@ -144,7 +144,7 @@ Choose **Tools** > **NuGet Package Manager** > **Manage NuGet Packages for Solut
 ```
 Amazon.CDK.AWS.EC2
 Amazon.CDK.AWS.ECS
-AMazon.CDK.AWS.ECS.Patterns
+Amazon.CDK.AWS.ECS.Patterns
 ```
 
 **Tip**  


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
This PR fixes a typo in the NuGet package name for ECS. The correct package name is `Amazon.CDK.AWS.ECS.Patterns`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
