### PR TITLE
Fix error in Java MyPipelineStack

### DIFF
--- a/doc_source/cdk_pipeline.md
+++ b/doc_source/cdk_pipeline.md
@@ -392,7 +392,7 @@ public class MyPipelineStack extends Stack {
              .pipelineName("MyPipeline")
              .synth(ShellStep.Builder.create("Synth")
                 .input(CodePipelineSource.gitHub("OWNER/REPO", "main"))
-                .commands(Arrays.asList)"npm ci", "npm run build", "npx cdk synth"))
+                .commands(Arrays.asList("npm install -g aws-cdk", "cdk synth"))
                 .build())
              .build();
     }


### PR DESCRIPTION
*Overview*
- For Java projects there is no `package.json` to install AWS-CDK. This causes errors when attempting to deploy the pipeline as the `npm ci` step depends on this file.
- Fixed the commands to `Arrays.asList("npm install -g aws-sdk", "cdk synth")` to correct this behavior.

*Testing*
- Created new pipeline following the updated steps and was successful in pipeline creation and deployment.

*Relevant links*
- [Synth and Sources](https://docs.aws.amazon.com/cdk/api/latest/docs/pipelines-readme.html#synth-and-sources). In the Java section this behavior and fix are both addressed.

*Issue #, if available:* n/a

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.