### PR TITLE
Add quotes to CDK alias commands on Mac/Linux

### DIFF
--- a/doc_source/work-with-cdk-v2.md
+++ b/doc_source/work-with-cdk-v2.md
@@ -21,8 +21,8 @@ npx cdk@2.x init app --language typescript
 Set up command line aliases so you can use cdk and cdk2 commands to invoke the desired version of the CDK Toolkit\.  
 
 ```
-alias cdk=npx aws-cdk@1.x
-alias cdk2=npx aws-cdk@2.x
+alias cdk="npx aws-cdk@1.x"
+alias cdk2="npx aws-cdk@2.x"
 ```
 
 ```


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The CDK alias commands on Mac and Linux require quotes, otherwise the alias will only map the first component of the command before the space. This was verified in bash on both MacOS 11.6 and Amazon Linux 2. Adding the quotes as this PR does fixes the alias commands to work as intended.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
