### PR TITLE
Drop 'rc1' from python and javascript instructions

### DIFF
--- a/v2/migrating-v2.md
+++ b/v2/migrating-v2.md
@@ -195,7 +195,7 @@ Experimental constructs are provided in separate, independently\-versioned packa
 ```
 {
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0-rc.1",
+    "aws-cdk-lib": "^2.0.0",
     "@aws-cdk/aws-codestar-alpha": "2.0.0-alpha.1",
     "constructs": "^10.0.0"
   }
@@ -222,7 +222,7 @@ Experimental constructs are provided in separate, independently\-versioned packa
 
 ```
 install_requires=[
-     "aws-cdk-lib>=2.0.0rc1",
+     "aws-cdk-lib>=2.0.0",
      "constructs>=10.0.0",
      "aws-cdk.aws-codestar-alpha>=2.0.0alpha1",
      # ...


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
