### PR TITLE
fix: Update interface for CDKv2

### DIFF
--- a/v2/sam.md
+++ b/v2/sam.md
@@ -26,7 +26,7 @@ The instructions here apply to the current \(non\-preview\) version of the AWS S
    new lambda.Function(this, 'MyFunction', {
      runtime: lambda.Runtime.PYTHON_3_7,
      handler: 'app.lambda_handler',
-     code:    lambda.Code.asset('./my_function'),
+     code:    lambda.Code.fromAsset('./my_function'),
    });
    ```
 


### PR DESCRIPTION
https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda.Code.html#static-fromwbrassetpath-options

*Issue #, if available:*

*Description of changes:*
`lambda.Code.asset` does not exist anymore in CDKv2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
