### PR TITLE
fix typo in C# csproj library Include

### DIFF
--- a/v2/migrating-v2.md
+++ b/v2/migrating-v2.md
@@ -297,7 +297,7 @@ Experimental constructs are provided in separate, independently\-versioned packa
 
 ```
 <PackageReference Include="Amazon.CDK.Lib" Version="2.0.0" />
-<PackageReference include="Amazon.CDK.AWS.Codestar.Alpha" Version="2.0.0-alpha.1" />
+<PackageReference Include="Amazon.CDK.AWS.Codestar.Alpha" Version="2.0.0-alpha.1" />
 <PackageReference Include="Constructs" Version="10.0.0" />
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
visual studio will throw error for the mentioned changes in csproj ,  

*Description of changes:*
csproj package reference should be `Include` not `include`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
