### PR TITLE
Update description of CDK bootstrap behaviour

### DIFF
--- a/v2/bootstrapping.md
+++ b/v2/bootstrapping.md
@@ -136,7 +136,7 @@ The policies must be passed as a single string argument, with the policy ARNs se
   --cloudformation-execution-policies "arn:aws:iam::aws:policy/AWSLambda_FullAccess,arn:aws:iam::aws:policy/AWSCodeDeployFullAccess".
   ```
 **Important**  
-At least one policy should be specified; otherwise, AWS CloudFormation will deploy with `FullAdmin` permissions\.
+At least one policy should be specified; otherwise, AWS CloudFormation will deploy with full admin permissions from the `AdministratorAccess` policy\.
 + \-\-qualifier a string that is added to the names of all resources in the bootstrap stack\. A qualifier lets you avoid name clashes when you provision two bootstrap stacks in the same environment\. The default is `hnb659fds` \(this value has no significance\)\. Changing the qualifier will require changes to your AWS CDK app \(see [Stack synthesizers](#bootstrapping-synthesizers)\)\. 
 + \-\-tags adds one or more AWS CloudFormation tags to the bootstrap stack\.
 + \-\-trust lists the AWS accounts that may deploy into the environment being bootstrapped\. Use this flag when bootstrapping an environment that a CDK Pipeline in another environment will deploy into\. The account doing the bootstrapping is always trusted\.

--- a/v2/bootstrapping.md
+++ b/v2/bootstrapping.md
@@ -129,14 +129,14 @@ The following command\-line options, when used with CDK Toolkit's cdk bootstrap,
 +  \-\-bootstrap\-bucket\-name overrides the name of the Amazon S3 bucket\. May require changes to your CDK app \(see [Stack synthesizers](#bootstrapping-synthesizers)\)\.
 + \-\-bootstrap\-kms\-key\-id overrides the AWS KMS key used to encrypt the S3 bucket\.
 + \-\-cloudformation\-execution\-policies specifies the ARNs of managed policies that should be attached to the deployment role assumed by AWS CloudFormation during deployment of your stacks\.
-**Tip**  
-The policies must be passed as a single string argument, with the policy ARNs separated by commas, like this:  
+  **Tip**  
+  The policies must be passed as a single string argument, with the policy ARNs separated by commas, like this:  
 
-  ```
-  --cloudformation-execution-policies "arn:aws:iam::aws:policy/AWSLambda_FullAccess,arn:aws:iam::aws:policy/AWSCodeDeployFullAccess".
-  ```
-**Important**  
-At least one policy should be specified; otherwise, AWS CloudFormation will deploy with full admin permissions from the `AdministratorAccess` policy\.
+    ```
+    --cloudformation-execution-policies "arn:aws:iam::aws:policy/AWSLambda_FullAccess,arn:aws:iam::aws:policy/AWSCodeDeployFullAccess".
+    ```
+  **Important**  
+  At least one policy should be specified; otherwise, AWS CloudFormation will deploy with full admin permissions from the `AdministratorAccess` policy\.
 + \-\-qualifier a string that is added to the names of all resources in the bootstrap stack\. A qualifier lets you avoid name clashes when you provision two bootstrap stacks in the same environment\. The default is `hnb659fds` \(this value has no significance\)\. Changing the qualifier will require changes to your AWS CDK app \(see [Stack synthesizers](#bootstrapping-synthesizers)\)\. 
 + \-\-tags adds one or more AWS CloudFormation tags to the bootstrap stack\.
 + \-\-trust lists the AWS accounts that may deploy into the environment being bootstrapped\. Use this flag when bootstrapping an environment that a CDK Pipeline in another environment will deploy into\. The account doing the bootstrapping is always trusted\.

--- a/v2/bootstrapping.md
+++ b/v2/bootstrapping.md
@@ -55,7 +55,7 @@ cdk bootstrap aws://123456789012/us-east-1
 cdk bootstrap 123456789012/us-east-1 123456789012/us-west-1
 ```
 
-The AWS CDK Toolkit always synthesizes the AWS CDK app in the current directory, and if you do not specify at least one environment in the cdk bootstrap command it will bootstrap all the environments referenced in the app\. If a stack is environment\-agnostic \(that is, it does not have an `env` property\), the CDK's environment \(for example, the one specified using \-\-profile, or the default AWS environment otherwise\) is applied to make the stack environment\-specific, and that environment is then bootstrapped\.
+The AWS CDK Toolkit always synthesizes the AWS CDK app in the current directory, and if you do not specify at least one environment in the `cdk bootstrap` command it will bootstrap all the environments referenced in the app\. If a stack is environment\-agnostic \(that is, it does not have an `env` property\), the CDK's environment \(for example, the one specified using \-\-profile, or the default AWS environment otherwise\) is applied to make the stack environment\-specific, and that environment is then bootstrapped\.
 
 For example, the following command synthesizes the current AWS CDK app using the `prod` AWS profile, then bootstraps its environments\.
 

--- a/v2/bootstrapping.md
+++ b/v2/bootstrapping.md
@@ -136,7 +136,7 @@ The following command\-line options, when used with CDK Toolkit's cdk bootstrap,
     --cloudformation-execution-policies "arn:aws:iam::aws:policy/AWSLambda_FullAccess,arn:aws:iam::aws:policy/AWSCodeDeployFullAccess".
     ```
   **Important**  
-  At least one policy should be specified; otherwise, AWS CloudFormation will deploy with full admin permissions from the `AdministratorAccess` policy\.
+  At least one policy should be specified; otherwise, AWS CloudFormation will deploy using full administrator permissions from the `AdministratorAccess` policy\.
 + \-\-qualifier a string that is added to the names of all resources in the bootstrap stack\. A qualifier lets you avoid name clashes when you provision two bootstrap stacks in the same environment\. The default is `hnb659fds` \(this value has no significance\)\. Changing the qualifier will require changes to your AWS CDK app \(see [Stack synthesizers](#bootstrapping-synthesizers)\)\. 
 + \-\-tags adds one or more AWS CloudFormation tags to the bootstrap stack\.
 + \-\-trust lists the AWS accounts that may deploy into the environment being bootstrapped\. Use this flag when bootstrapping an environment that a CDK Pipeline in another environment will deploy into\. The account doing the bootstrapping is always trusted\.

--- a/v2/bootstrapping.md
+++ b/v2/bootstrapping.md
@@ -128,13 +128,15 @@ There are two ways to customize the bootstrapping resources\.
 The following command\-line options, when used with CDK Toolkit's cdk bootstrap, provide commonly\-needed adjustments to the bootstrapping template\.
 +  \-\-bootstrap\-bucket\-name overrides the name of the Amazon S3 bucket\. May require changes to your CDK app \(see [Stack synthesizers](#bootstrapping-synthesizers)\)\.
 + \-\-bootstrap\-kms\-key\-id overrides the AWS KMS key used to encrypt the S3 bucket\.
-+ \-\-cloudformation\-execution\-policies specifies the ARNs of managed policies that should be attached to the deployment role assumed by AWS CloudFormation during deployment of your stacks\. At least one policy is required; otherwise, AWS CloudFormation will attempt to deploy without permissions and deployments will fail\.
++ \-\-cloudformation\-execution\-policies specifies the ARNs of managed policies that should be attached to the deployment role assumed by AWS CloudFormation during deployment of your stacks\.
 **Tip**  
 The policies must be passed as a single string argument, with the policy ARNs separated by commas, like this:  
 
   ```
   --cloudformation-execution-policies "arn:aws:iam::aws:policy/AWSLambda_FullAccess,arn:aws:iam::aws:policy/AWSCodeDeployFullAccess".
   ```
+**Important**  
+At least one policy should be specified; otherwise, AWS CloudFormation will deploy with `FullAdmin` permissions\.
 + \-\-qualifier a string that is added to the names of all resources in the bootstrap stack\. A qualifier lets you avoid name clashes when you provision two bootstrap stacks in the same environment\. The default is `hnb659fds` \(this value has no significance\)\. Changing the qualifier will require changes to your AWS CDK app \(see [Stack synthesizers](#bootstrapping-synthesizers)\)\. 
 + \-\-tags adds one or more AWS CloudFormation tags to the bootstrap stack\.
 + \-\-trust lists the AWS accounts that may deploy into the environment being bootstrapped\. Use this flag when bootstrapping an environment that a CDK Pipeline in another environment will deploy into\. The account doing the bootstrapping is always trusted\.

--- a/v2/bootstrapping.md
+++ b/v2/bootstrapping.md
@@ -55,7 +55,7 @@ cdk bootstrap aws://123456789012/us-east-1
 cdk bootstrap 123456789012/us-east-1 123456789012/us-west-1
 ```
 
-If you do not specify at least one environment in the `cdk bootstrap` command, the AWS CDK Toolkit synthesizes the AWS CDK app in the current directory and bootstraps all the environments referenced in the app\. If a stack is environment\-agnostic \(that is, it does not have an `env` property\), the CDK's environment \(for example, the one specified using \-\-profile, or the default AWS environment otherwise\) is applied to make the stack environment\-specific, and that environment is then bootstrapped\.
+The AWS CDK Toolkit always synthesizes the AWS CDK app in the current directory, and if you do not specify at least one environment in the cdk bootstrap command it will bootstrap all the environments referenced in the app\. If a stack is environment\-agnostic \(that is, it does not have an `env` property\), the CDK's environment \(for example, the one specified using \-\-profile, or the default AWS environment otherwise\) is applied to make the stack environment\-specific, and that environment is then bootstrapped\.
 
 For example, the following command synthesizes the current AWS CDK app using the `prod` AWS profile, then bootstraps its environments\.
 


### PR DESCRIPTION
*Description of changes:*

Two independent documentation changes based on my experience bootstrapping with CDK v2.15.0

1. The documentation doesn't reflect the current behaviour of bootstrap when run in a directory that contains a CDK app. It incorrectly implies that if you provide an environment on the command line then the app won't be synthesised. Synthesis is problematic if the app requires context arguments.
2. Using `AdministratorAccess` as the default IAM policy for deploying CloudFormation stacks is surprising, and should be  highlighted. At the very least, the documentation should not incorrectly imply that the default behaviour is for the deploy to fail because it has no permissions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
