### PR TITLE
Update serverless_example.md

### DIFF
--- a/v2/serverless_example.md
+++ b/v2/serverless_example.md
@@ -53,7 +53,7 @@ cdk init --language javascript
 mkdir MyWidgetService
 cd MyWidgetService
 cdk init --language python
-source .venv/bin/activate
+source .env/bin/activate
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
Python CDK is using .env not .venv

*Issue #, if available:*

If you follow the commands for Python as listed you get an error that no such directory exists

*Description of changes:*

I changed the path from .venv to .env because that's the output of the CDK if you follow these steps

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
