### PR TITLE
Added version note for bootstrap template v13

### DIFF
--- a/v2/bootstrapping.md
+++ b/v2/bootstrapping.md
@@ -575,3 +575,4 @@ The bootstrap template is versioned and evolves over time with the AWS CDK itsel
 | 10 | 2\.4\.0 | ECR ScanOnPush is now enabled by default\. | 
 | 11 | 2\.18\.0 | Adds policy allowing Lambda to pull from Amazon ECR repos so it survives rebootstrapping\. | 
 | 12 | 2\.20\.0 | Adds support for experimental cdk import\. | 
+| 13 | 2\.25\.0 | Makes ECR images immutable when created from cdk bootstrap\. | 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Quick update to include new template version (13) introduced in [2.25.0](https://github.com/aws/aws-cdk/releases/tag/v2.25.0).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
