### PR TITLE
Clarifies the Arrays.asList method

### DIFF
--- a/v2/work-with-cdk-java.md
+++ b/v2/work-with-cdk-java.md
@@ -104,10 +104,10 @@ To create maps with more than ten entries, use [https://docs.oracle.com/javase/9
 
 If you are using Java 8, you could provide your own methods similar to to these\.
 
-JavaScript arrays are represented as `List<Object>` or `List<String>` in Java\. The method `java.util.Arrays.asList` is convenient for defining short `ArrayList`s\.
+JavaScript arrays are represented as `List<Object>` or `List<String>` in Java\. The method `java.util.Arrays.asList` is convenient for defining short `List`s\.
 
 ```
-String[] cmds = Arrays.asList("cd lambda", "npm install", "npm install typescript")
+List<String> cmds = Arrays.asList("cd lambda", "npm install", "npm install typescript")
 ```
 
 ### Missing values<a name="java-missing-values"></a>


### PR DESCRIPTION
The list returned by Arrays.asList is Arrays$ArrayList, not ArrayList. Since one is unmodifiable and one is not, this can trip up people. It should also be noted that Java 8's docs says Arrays.asList returns List, not ArrayList[1]. So to make sure that the docs always smell of freshly baked quality, I propose this modest change.

[1] https://docs.oracle.com/javase/8/docs/api/java/util/Arrays.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
