### PR TITLE
fix: Add Construct import in python code for Create CDK Pipeline page

### DIFF
--- a/v2/cdk_pipeline.md
+++ b/v2/cdk_pipeline.md
@@ -269,6 +269,7 @@ In `my-pipeline/my-pipeline-stack.py` \(may vary if your project folder isn't na
 ```
 import aws_cdk as cdk
 from aws_cdk.pipelines import CodePipeline, CodePipelineSource, ShellStep
+from constructs import Construct
 
 class MyPipelineStack(cdk.Stack):
 

--- a/v2/cdk_pipeline.md
+++ b/v2/cdk_pipeline.md
@@ -1203,7 +1203,7 @@ stage = pipeline.add_stage(MyApplicationStage(self, "test",
             env=cdk.Environment(account="111111111111", region="eu-west-1")))
 
 stage.add_post(ShellStep("validate", input=source,
-    commands=["curl -Ssf https://my.webservice.com/"],
+    commands=["sh ./tests/validate.sh"],
 ))
 ```
 


### PR DESCRIPTION
At the moment Construct is undefined when defining the cdk.Stack. This commit imports Construct from constructs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
