### PR TITLE
Remove duplicate code example

### DIFF
--- a/v2/hello_world.md
+++ b/v2/hello_world.md
@@ -487,20 +487,6 @@ Update `hello-cdk.go`\.
 ```
 
 ------
-#### [ C\# ]
-
-Update `src/HelloCdk/HelloCdkStack.cs`\.
-
-```
-new Bucket(this, "MyFirstBucket", new BucketProps
-{
-    Versioned = true,
-    RemovalPolicy = RemovalPolicy.DESTROY,
-    AutoDeleteObjects = true
-});
-```
-
-------
 
 Here, we haven't written any code that, in itself, changes our Amazon S3 bucket\. Instead, our code defines the desired state of the bucket\. The AWS CDK synthesizes that state to a new AWS CloudFormation template\. Then, it deploys a changeset that makes only the changes necessary to reach that state\.
 


### PR DESCRIPTION
In the **Modifying the app** section, the code example for C# is duplicated. This change simply removes the one that is out of place and leaves the other.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
