### PR TITLE
Fixing CDK python example import typo

### DIFF
--- a/v2/cdk_pipeline.md
+++ b/v2/cdk_pipeline.md
@@ -268,7 +268,7 @@ In `my-pipeline/my-pipeline-stack.py` \(may vary if your project folder isn't na
 
 ```
 import aws_cdk as cdk
-from constructs import Constuct
+from constructs import Construct
 from aws_cdk.pipelines import CodePipeline, CodePipelineSource, ShellStep
 
 class MyPipelineStack(cdk.Stack):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The `Construct` import in the python example has a typo. That's all =) Thank you


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
