### PR TITLE
Remove duplicated statement in "v2/work-with-cdk-go.md" file and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ to see what we're working on at the moment. Note that items on the Wishlist may 
 
 ## Contributor Grant of License
 
-By submitting a Pull Request against this repo, you grant Amazon the right to use use, modify, copy, and redistribute your contribution 
+By submitting a Pull Request against this repo, you grant Amazon the right to use, modify, copy, and redistribute your contribution 
 under any license we choose.

--- a/v2/work-with-cdk-go.md
+++ b/v2/work-with-cdk-go.md
@@ -56,10 +56,6 @@ Field and method names use camel casing \(`likeThis`\) in TypeScript, the CDK's 
 
 In your `main` method, use `defer jsii.Close()` to make sure your CDK app cleans up after itself\.
 
-### Field and method names<a name="go-naming"></a>
-
-Field and method names use camel casing \(`likeThis`\) in TypeScript, the CDK's language of origin\. In Go, these follow Go conventions, so are Pascal\-cased \(`LikeThis`\)\.
-
 ### Missing values and pointer conversion<a name="go-missing-values"></a>
 
 In Go, missing values in AWS CDK objects such as property bundles are represented by `nil`\. Go doesn't have nullable types; the only type that can contain `nil` is a pointer\. To allow values to be optional, then, all CDK properties, arguments, and return values are pointers, even for primitive types\. This applies to required values as well as optional ones, so if a required value later becomes optional, no breaking change in type is needed\.


### PR DESCRIPTION
~*Issue #, if available:*~

Description of changes:
This PR holds the changes for removing some duplicated statements listed below:
1. In the README file, under the `Contributor Grant of License` there's a duplicated `use`.
2. In the `v2/work-with-cdk-go.md`, inside the `AWS CDK idioms in Go` section, there's a duplication of the `Field and method names` statement. (Lines 51-53 and lines 59-62).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
