### PR TITLE
Update cdk_pipeline.md

### DIFF
--- a/v2/cdk_pipeline.md
+++ b/v2/cdk_pipeline.md
@@ -452,7 +452,7 @@ export class MyLambdaStack extends cdk.Stack {
       super(scope, id, props);
 
       new Function(this, 'LambdaFunction', {
-        runtime: Runtime.NODEJS_12_X,
+        runtime: Runtime.NODEJS_18_X,
         handler: 'index.handler',
         code: new InlineCode('exports.handler = _ => "Hello, CDK";')
       });


### PR DESCRIPTION
Runtime version of the example Lambda is updated to **NODEJS_18_X** . 
The previous version **NODEJS_12_X** is deprecated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.