### PR TITLE
fix(docs): Syntax errors in typescript and javascript aspect examples

### DIFF
--- a/v2/aspects.md
+++ b/v2/aspects.md
@@ -111,7 +111,7 @@ class BucketVersioningChecker implements IAspect {
       // can be a token (IResolvable).
       if (!node.versioningConfiguration
         || (!Tokenization.isResolvable(node.versioningConfiguration)
-            && node.versioningConfiguration.status !== 'Enabled') {
+            && node.versioningConfiguration.status !== 'Enabled')) {
         Annotations.of(node).addError('Bucket versioning is not enabled');
       }
     }
@@ -135,7 +135,7 @@ class BucketVersioningChecker {
       // can be a token (IResolvable).
       if (!node.versioningConfiguration
         || !Tokenization.isResolvable(node.versioningConfiguration)
-            && node.versioningConfiguration.status !== 'Enabled') {
+            && node.versioningConfiguration.status !== 'Enabled')) {
         Annotations.of(node).addError('Bucket versioning is not enabled');
       }
     }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- I made the typescript/javascript examples work by adding a right-parenthesis in the `if` statment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
