### PR TITLE
added tagging code examples in golang

### DIFF
--- a/v2/tagging.md
+++ b/v2/tagging.md
@@ -54,6 +54,13 @@ Tags.Of(myConstruct).Add("key", "value");
 ```
 
 ------
+#### [ Go ]
+
+```
+awscdk.Tags_Of(myConstruct).Add(jsii.String("key"), jsii.String("value"), &awscdk.TagProps{})
+```
+
+------
 
 The following example deletes the tag **key** from a construct\.
 
@@ -90,6 +97,13 @@ Tags.of(myConstruct).remove("key");
 
 ```
 Tags.Of(myConstruct).Remove("key");
+```
+
+------
+#### [ Go ]
+
+```
+awscdk.Tags_Of(myConstruct).Remove(jsii.String("key"), &awscdk.TagProps{})
 ```
 
 ------
@@ -140,6 +154,15 @@ Tags.of(myConstruct).add("key", "value", TagProps.builder()
 
 ```
 Tags.Of(myConstruct).Add("key", "value", new TagProps { Priority = 300 });
+```
+
+------
+#### [ Go ]
+
+```
+awscdk.Tags_Of(myConstruct).Add(jsii.String("key"), jsii.String("value"), &awscdk.TagProps{
+    Priority: jsii.Number(300),
+})
 ```
 
 ------
@@ -198,7 +221,7 @@ Tags.of(my_construct).add("tagname", "value",
 #### [ Java ]
 
 ```
-Tags.of(myConstruct).add("key", "value", TagProps.builder()
+Tags.of(myConstruct).add("tagname", "value", TagProps.builder()
                 .applyToLaunchedInstances(false)
                 .includeResourceTypes(Arrays.asList("AWS::Xxx::Yyy"))
                 .excludeResourceTypes(Arrays.asList("AWS::Xxx::Zzz"))
@@ -216,6 +239,18 @@ Tags.Of(myConstruct).Add("tagname", "value", new TagProps
     ExcludeResourceTypes = ["AWS::Xxx::Zzz"],
     Priority = 100
 });
+```
+
+------
+#### [ Go ]
+
+```
+awscdk.Tags_Of(myConstruct).Add(jsii.String("tagname"), jsii.String("value"), &awscdk.TagProps{
+    ApplyToLaunchedInstances: jsii.Bool(false),
+    IncludeResourceTypes:     &[]*string{jsii.String("AWS::Xxx:Yyy")},
+    ExcludeResourceTypes:     &[]*string{jsii.String("AWS::Xxx:Zzz")},
+    Priority:                 jsii.Number(100),
+})
 ```
 
 ------
@@ -274,6 +309,17 @@ Tags.Of(myConstruct).Remove("tagname", new TagProps
     ExcludeResourceTypes = ["AWS::Xxx::Zzz"],
     Priority = 100
 });
+```
+
+------
+#### [ Go ]
+
+```
+awscdk.Tags_Of(myConstruct).Remove(jsii.String("tagname"), &awscdk.TagProps{
+    IncludeResourceTypes: &[]*string{jsii.String("AWS::Xxx:Yyy")},
+    ExcludeResourceTypes: &[]*string{jsii.String("AWS::Xxx:Zzz")},
+    Priority:             jsii.Number(200),
+})
 ```
 
 ------
@@ -371,6 +417,24 @@ Tags.Of(theBestStack).Remove("StackType", new TagProps
 ```
 
 ------
+#### [ Go ]
+
+```
+import "github.com/aws/aws-cdk-go/awscdk/v2"
+
+app := awscdk.NewApp(nil)
+theBestStack := awscdk.NewStack(app, jsii.String("MarketingSystem"), &awscdk.StackProps{})
+
+// Add a tag to all constructs in the stack
+awscdk.Tags_Of(theBestStack).Add(jsii.String("StackType"), jsii.String("TheBest"), &awscdk.TagProps{})
+
+// Remove the tag from all resources except subnet resources
+awscdk.Tags_Of(theBestStack).Add(jsii.String("StackType"), jsii.String("TheBest"), &awscdk.TagProps{
+    ExcludeResourceTypes: &[]*string{jsii.String("AWS::EC2::Subnet")},
+})
+```
+
+------
 
 The following code achieves the same result\. Consider which approach \(inclusion or exclusion\) makes your intent clearer\.
 
@@ -417,6 +481,15 @@ Tags.Of(theBestStack).Add("StackType", "TheBest", new TagProps {
 ```
 
 ------
+#### [ Go ]
+
+```
+awscdk.Tags_Of(theBestStack).Add(jsii.String("StackType"), jsii.String("TheBest"), &awscdk.TagProps{
+    IncludeResourceTypes: &[]*string{jsii.String("AWS::EC2::Subnet")},
+})
+```
+
+------
 
 ## Tagging single constructs<a name="tagging_single"></a>
 
@@ -459,6 +532,13 @@ Tag.Builder.create(key, value).build().visit(scope);
 
 ```
 new Tag(key, value).Visit(scope);
+```
+
+------
+#### [ Go ]
+
+```
+awscdk.NewTag(key, value, &awscdk.TagProps{}).Visit(scope)
 ```
 
 ------


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added tagging examples in golang (and fixed one wrong java naming "key"/"tagname") 

I had Problems translating the last example. The Interface implementation and overwriting of "Visit()", while still having an Struct ("Object") of type IAspect is not possible, at least I dont know how to do this. Is it even doable, with golang not beeing OO? Would be great to know. Would suggest adding a Go section regardless, with a comment stating the problem, so users know why there is no example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
