### PR TITLE
feat: add CODEOWNERS file for CDK guide approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @awsdocs/cdk-guide-approvers


### PR DESCRIPTION
## Description

**Documentation Change Type:**

N/A. Change is internal to management of this repo.

**Affected Documentation Page(s):**
Repository-wide code ownership configuration

## Description of Changes
Added a CODEOWNERS file to establish code ownership for the AWS CDK Developer Guide repository. This file designates @awsdocs/cdk-guide-approvers as the default reviewers for all changes.

## Motivation and Context
This change establishes proper code ownership and review processes for the repository, ensuring that appropriate team members are automatically assigned as reviewers for pull requests.

## How Has This Been Validated?
The CODEOWNERS file follows GitHub's standard format and syntax.

## Checklist

- [x] My changes follow the [AsciiDoc syntax](./CONTRIBUTING.md#asciidoc-syntax-reference) guidelines
- [x] I have previewed my changes using GitHub's preview or a local AsciiDoc renderer
- [x] My changes maintain consistent formatting with the rest of the documentation
- [x] I have checked that all links work correctly

## Additional Information
This CODEOWNERS file will automatically request reviews from the CDK guide approvers team for all changes to the repository.