### PR TITLE
Update home.adoc to expand on the definition of the CDK Toolkit

### DIFF
--- a/v2/guide/home.adoc
+++ b/v2/guide/home.adoc
@@ -20,7 +20,7 @@ The {aws} CDK consists of two primary parts:
 
 * *xref:constructs[{aws} CDK Construct Library]* – A collection of pre-written modular and reusable pieces of code, called constructs, that you can use, modify, and integrate to develop your infrastructure quickly. The goal of the {aws} CDK Construct Library is to reduce the complexity required to define and integrate {aws} services together when building applications on {aws}.
 
-* *xref:cli[{aws} CDK Command Line Interface ({aws} CDK CLI)]* – A command line tool for interacting with CDK apps. Use the CDK CLI to create, manage, and deploy your {aws} CDK projects. The CDK CLI is also referred to as the CDK Toolkit.
+* {aws} CDK Toolkit - Tools that you can use to manage and interact with your CDK apps, such as performing synthesis or deployment. The CDK Toolkit consists of a command line tool (xref:ref-cli-cmd[CDK CLI]) and a programmatic library (xref:toolkit-library[CDK Toolkit Library]).
 
 The {aws} CDK supports  TypeScript,  JavaScript,  Python,  Java,  C#/.Net, and  [.noloc]`Go`. You can use any of these supported programming languages to define reusable cloud components known as  xref:constructs[constructs]. You compose these together into xref:stacks[stacks] and xref:apps[apps]. Then, you deploy your CDK applications to {aws} CloudFormation to provision or update your resources.
 

--- a/v2/guide/home.adoc
+++ b/v2/guide/home.adoc
@@ -22,7 +22,7 @@ The {aws} CDK consists of two primary parts:
 
 * {aws} CDK Toolkit - Tools that you can use to manage and interact with your CDK apps, such as performing synthesis or deployment. The CDK Toolkit consists of a command line tool (xref:ref-cli-cmd[CDK CLI]) and a programmatic library (xref:toolkit-library[CDK Toolkit Library]).
 
-The {aws} CDK supports  TypeScript,  JavaScript,  Python,  Java,  C#/.Net, and  [.noloc]`Go`. You can use any of these supported programming languages to define reusable cloud components known as  xref:constructs[constructs]. You compose these together into xref:stacks[stacks] and xref:apps[apps]. Then, you deploy your CDK applications to {aws} CloudFormation to provision or update your resources.
+The {aws} CDK supports  TypeScript,  JavaScript,  Python,  Java,  C#/.Net, and  [.noloc]`Go`. You can use any of these supported programming languages to define reusable cloud components known as  xref:constructs[constructs]. You compose these together into xref:stacks[stacks] and xref:apps[apps]. Then, you deploy your CDK applications through {aws} CloudFormation to provision or update your resources.
 
 image::./images/AppStacks.png["CDK app and process overview"]
 


### PR DESCRIPTION
Update the introduction to the CDK to expand on the definition of the CDK Toolkit with the introduction of the CDK Toolkit Library, for clarification purposes.

## Description

**Documentation Change Type:**

- [ ] Typo/grammar fix
- [X] Clarification or minor improvement
- [ ] New example or code snippet
- [ ] New section or topic
- [ ] Major restructuring or enhancement

**Affected Documentation Page(s):**
https://docs.aws.amazon.com/cdk/v2/guide/home.html

## Description of Changes
Update description of the CDK Toolkit to include the CDK CLI and CDK Toolkit Library

## Motivation and Context
Clarify terminology around the CDK Toolkit and CDK CLI

## How Has This Been Validated?
Used GitHub's preview functionality

## Screenshots (if appropriate)
<!-- Include screenshots of the documentation before and after your changes -->

## Checklist

- [X] My changes follow the [AsciiDoc syntax](./CONTRIBUTING.md#asciidoc-syntax-reference) guidelines
- [X] I have previewed my changes using GitHub's preview or a local AsciiDoc renderer
- [X] My changes maintain consistent formatting with the rest of the documentation
- [X] I have checked that all links work correctly

## Additional Information
<!-- Any additional information or context that might be helpful for reviewers -->
