### PR TITLE
Remove preview note from blueprints documentation

### DIFF
--- a/v2/guide/blueprints.adoc
+++ b/v2/guide/blueprints.adoc
@@ -13,13 +13,6 @@ CDK Blueprints allow organizations to standardize L2 construct configurations th
 
 // Content start
 
-[NOTE]
-====
-
-CDK Blueprints is in preview release and is subject to change.
-
-====
-
 Use {aws} CDK Blueprints to standardize and distribute L2 construct configurations across your organization. With Blueprints, you can ensure that {aws} resources are configured consistently according to your organizational standards and best practices. For example, you can automatically enable encryption for all Amazon S3 buckets, apply specific logging configurations to all {aws} Lambda functions, or enforce standard security rules for all security groups.
 
 Blueprints are powered by _property injection_, a mechanism introduced in {aws} CDK link:https://github.com/aws/aws-cdk/releases/tag/v2.196.0[v2.196.0] that allows you to modify construct properties at instantiation time. A Blueprint is a collection of property injectors, where each property injector specifies optimal configuration for a specific L2 construct. The Blueprint represents the overall best practices for your organization.


### PR DESCRIPTION
## Description

**Documentation Change Type:**

- [ ] Typo/grammar fix
- [X] Clarification or minor improvement
- [ ] New example or code snippet
- [ ] New section or topic
- [ ] Major restructuring or enhancement

**Affected Documentation Page(s):**
- https://docs.aws.amazon.com/cdk/v2/guide/blueprints.html

## Description of Changes
The Blueprints aka Property Injection feature is live since more than 3 months now. We don't plan to introduce any major changes to this feature. At this point, we feel confident that all CDK customers can leverage this feature. This change is to remove the **"CDK Blueprints is in preview release and is subject to change"** note banner from the documentation page.

## Motivation and Context
The Blueprints aka Property Injection feature is live since more than 3 months now. We don't plan to introduce any major changes to this feature. At this point, we feel confident that all CDK customers can leverage this feature. This change is to remove the **"CDK Blueprints is in preview release and is subject to change"** note banner from the documentation page.

## How Has This Been Validated?
Change is small enough to be reviewed manually.

## Screenshots (if appropriate)
- https://docs.aws.amazon.com/cdk/v2/guide/blueprints.html

## Checklist

- [X] My changes follow the [AsciiDoc syntax](./CONTRIBUTING.md#asciidoc-syntax-reference) guidelines
- [X] I have previewed my changes using GitHub's preview or a local AsciiDoc renderer
- [X] My changes maintain consistent formatting with the rest of the documentation
- [X] I have checked that all links work correctly

## Additional Information
<!-- Any additional information or context that might be helpful for reviewers -->
