### PR TITLE
docs(cli): add `cdk publish-assets` command reference

### DIFF
--- a/v2/guide/doc-history.adoc
+++ b/v2/guide/doc-history.adoc
@@ -23,6 +23,11 @@ The table below represents significant documentation milestones. We fix errors a
 [.updates]
 == Updates
 
+[.update,date="2026-04-02"]
+=== Add documentation for the cdk publish-assets command
+
+Use the {aws} CDK CLI `cdk publish-assets` command to publish assets such as Docker images and file assets for your CDK stacks without performing a deployment. For more information, see link:https://docs.aws.amazon.com/cdk/v2/guide/ref-cli-cmd-publish-assets.html[`cdk publish-assets`].
+
 [.update,date="2025-09-08"]
 === Add documentation for preserving deployed resources when refactoring CDK code
 

--- a/v2/guide/ref-cli-cmd-publish-assets.adoc
+++ b/v2/guide/ref-cli-cmd-publish-assets.adoc
@@ -1,0 +1,118 @@
+include::attributes.txt[]
+
+// Attributes
+
+[.topic]
+[#ref-cli-cmd-publish-assets]
+= `cdk publish-assets`
+:keywords: {aws} CDK, {aws} CDK CLI, CDK Toolkit, IaC, Infrastructure as code, {aws} Cloud, {aws} CloudFormation, cdk publish-assets, assets, Amazon ECR, Amazon S3
+
+[abstract]
+--
+Publish assets for the specified {aws} CDK stack to their respective destinations without performing a deployment.
+--
+
+// Content start
+
+[IMPORTANT]
+====
+The `cdk publish-assets` command is in development for the {aws} CDK. The current features of this command are subject to change. Therefore, you must opt in by providing the `--unstable=publish-assets` option to use this command.
+====
+
+Publish assets such as Docker images and file assets for the specified {aws} Cloud Development Kit ({aws} CDK) stack to their respective destinations, such as Amazon Elastic Container Registry (Amazon ECR) repositories and Amazon Simple Storage Service (Amazon S3) buckets, without performing a deployment.
+
+This command is useful in CI/CD pipelines where you want to separate the asset publishing phase from the deployment phase. By publishing assets independently, you can validate that all assets are built and available before you start the deployment process.
+
+[#ref-cli-cmd-publish-assets-usage]
+== Usage
+
+[source,none,subs="verbatim,attributes"]
+----
+$ cdk publish-assets <arguments> <options>
+----
+
+[#ref-cli-cmd-publish-assets-args]
+== Arguments
+
+[#ref-cli-cmd-publish-assets-args-stack-name]
+*CDK stack ID*::
+The construct ID of the CDK stack from your app to publish assets for.
++
+_Type_: String
++
+_Required_: No
+
+[#ref-cli-cmd-publish-assets-options]
+== Options
+
+For a list of global options that work with all CDK CLI commands, see xref:ref-cli-cmd-options[Global options].
+
+[#ref-cli-cmd-publish-assets-options-all]
+`--all <BOOLEAN>`::
+Publish assets for all stacks in your CDK app.
++
+_Default value_: `false`
+
+[#ref-cli-cmd-publish-assets-options-concurrency]
+`--concurrency <NUMBER>`::
+Specify the maximum number of simultaneous asset publishing operations to perform.
++
+_Default value_: `4`
+
+[#ref-cli-cmd-publish-assets-options-exclusively]
+`--exclusively, -e <BOOLEAN>`::
+Only publish assets for requested stacks and don't include dependencies.
+
+[#ref-cli-cmd-publish-assets-options-force]
+`--force <BOOLEAN>`::
+Re-publish all assets, even if they already exist at the destination.
++
+_Default value_: `false`
+
+[#ref-cli-cmd-publish-assets-options-help]
+`--help, -h <BOOLEAN>`::
+Show command reference information for the `cdk publish-assets` command.
+
+[#ref-cli-cmd-publish-assets-examples]
+== Examples
+
+[#ref-cli-cmd-publish-assets-examples-1]
+=== Publish assets for a specific stack
+
+[source,none,subs="verbatim,attributes"]
+----
+$ cdk publish-assets MyStack --unstable=publish-assets
+----
+
+[#ref-cli-cmd-publish-assets-examples-2]
+=== Publish assets for all stacks
+
+[source,none,subs="verbatim,attributes"]
+----
+$ cdk publish-assets --all --unstable=publish-assets
+----
+
+[#ref-cli-cmd-publish-assets-examples-3]
+=== Force re-publish assets that already exist
+
+[source,none,subs="verbatim,attributes"]
+----
+$ cdk publish-assets MyStack --unstable=publish-assets --force
+----
+
+[#ref-cli-cmd-publish-assets-examples-4]
+=== Publish assets then deploy separately
+
+First, publish assets for your stack:
+
+[source,none,subs="verbatim,attributes"]
+----
+$ cdk publish-assets MyStack --unstable=publish-assets
+----
+
+Then, deploy the stack:
+
+[source,none,subs="verbatim,attributes"]
+----
+$ cdk deploy MyStack
+----

--- a/v2/guide/ref-cli-cmd.adoc
+++ b/v2/guide/ref-cli-cmd.adoc
@@ -91,6 +91,10 @@ Migrate {aws} resources, {aws} CloudFormation stacks, and {aws} CloudFormation t
 `xref:ref-cli-cmd-notices[notices]`::
 Display notices for your CDK application.
 
+[#ref-cli-cmd-commands-publish-assets]
+`xref:ref-cli-cmd-publish-assets[publish-assets]`::
+Publish assets for the specified CDK stack to their respective destinations without performing a deployment.
+
 [#ref-cli-cmd-commands-refactor]
 `xref:ref-cli-cmd-refactor[refactor]`::
 Preserve deployed resources when refactoring code in your CDK application.
@@ -393,6 +397,8 @@ include::ref-cli-cmd-metadata.adoc[leveloffset=+1]
 include::ref-cli-cmd-migrate.adoc[leveloffset=+1]
 
 include::ref-cli-cmd-notices.adoc[leveloffset=+1]
+
+include::ref-cli-cmd-publish-assets.adoc[leveloffset=+1]
 
 include::ref-cli-cmd-refactor.adoc[leveloffset=+1]
 


### PR DESCRIPTION
## Description

**Documentation Change Type:**

- [ ] Typo/grammar fix
- [ ] Clarification or minor improvement
- [ ] New example or code snippet
- [x] New section or topic
- [ ] Major restructuring or enhancement

**Affected Documentation Page(s):**
- https://docs.aws.amazon.com/cdk/v2/guide/ref-cli-cmd-publish-assets.html
- https://docs.aws.amazon.com/cdk/v2/guide/ref-cli-cmd.html

## Description of Changes

The CDK CLI recently added a `cdk publish-assets` command that lets users publish Docker images and file assets to their respective destinations (Amazon ECR and Amazon S3) without performing a deployment. This is particularly useful in CI/CD pipelines where the asset publishing phase needs to be separated from the deployment phase — for example, to validate that all assets are built and available before starting a deployment, or to run asset publishing in a different pipeline stage with different permissions.

The command is currently behind an `--unstable=publish-assets` opt-in flag while the feature is being finalized.

This PR adds a new reference page for `cdk publish-assets` that documents the command's usage, arguments, and options (`--all`, `--concurrency`, `--exclusively`, `--force`). It includes practical examples covering common workflows: publishing assets for a specific stack, publishing for all stacks, force re-publishing, and the two-step publish-then-deploy pattern. The page follows the same structure and conventions as the existing CLI command reference pages.

The CLI command index page (`ref-cli-cmd.adoc`) is updated to include `publish-assets` in alphabetical order among the other commands, and the document history is updated with a new entry.

## Motivation and Context

Users who build CI/CD pipelines around the CDK CLI often need fine-grained control over which phases of a deployment happen when. Until now, asset publishing was tightly coupled to `cdk deploy`, which meant there was no way to pre-publish assets in an earlier pipeline stage. The `cdk publish-assets` command addresses this gap, and the documentation needs to exist so users can discover and learn how to use it.

## How Has This Been Validated?

The page structure and option descriptions were verified against the CDK CLI source code and existing command reference pages for consistency.

## Checklist

- [x] My changes follow the [AsciiDoc syntax](./CONTRIBUTING.md#asciidoc-syntax-reference) guidelines
- [x] I have previewed my changes using GitHub's preview or a local AsciiDoc renderer
- [x] My changes maintain consistent formatting with the rest of the documentation
- [x] I have checked that all links work correctly
