### PR TITLE
docs: add cdk orphan CLI reference

### DIFF
--- a/v2/guide/ref-cli-cmd-orphan.adoc
+++ b/v2/guide/ref-cli-cmd-orphan.adoc
@@ -1,0 +1,128 @@
+include::attributes.txt[]
+
+// Attributes
+
+[.topic]
+[#ref-cli-cmd-orphan]
+= `cdk orphan`
+:info_titleabbrev: cdk orphan
+:keywords: {aws} CDK, {aws} CDK CLI, CDK Toolkit, IaC, Infrastructure as code, {aws} Cloud, {aws} CloudFormation, cdk orphan
+
+[abstract]
+--
+Safely detach resources from a CloudFormation stack without deleting them, enabling resource type migrations with zero downtime.
+--
+
+// Content start
+
+[IMPORTANT]
+====
+The `cdk orphan` command is in preview release and is subject to change.
+
+You must provide the `--unstable=orphan` option when using this command.
+====
+
+Safely detach one or more resources from an {aws} CloudFormation stack without deleting them. This is useful when you need to migrate a resource from one construct type to another (for example, migrating a DynamoDB `Table` to `TableV2`) without downtime or data loss.
+
+When you change a construct type in your CDK code, CloudFormation interprets this as a resource replacement, which deletes the existing resource and creates a new one. For stateful resources like databases and storage, this causes data loss. The `cdk orphan` command solves this by detaching the resource from the stack first, so you can re-import it under the new construct type using `cdk import`.
+
+With `cdk orphan`, you can:
+
+* Detach stateful resources from a stack before changing their construct type.
+* Migrate between construct versions (for example, DynamoDB `Table` to `TableV2`) without data loss.
+* Change the CloudFormation resource type backing a construct without replacing the physical resource.
+
+The orphan command performs three CloudFormation deployments:
+
+. *Resolve references*: Resolves cross-resource references (`Ref`, `Fn::GetAtt`, `Fn::Sub`) to the orphaned resources, so that other resources in the stack that depend on them continue to work after the orphaned resources are removed.
+. *Decouple*: Replaces all cross-resource references with their resolved literal values, sets `DeletionPolicy` to `Retain`, and removes `DependsOn` entries to isolate the resources from the rest of the stack.
+. *Remove*: Removes the resources from the CloudFormation template. The physical resources continue to exist in your {aws} account.
+
+After orphaning, update your CDK code to use the new construct type and use xref:ref-cli-cmd-import[cdk import] to bring the resource back under management.
+
+*To orphan a resource and re-import it under a new construct type*::
++
+. Deploy your stack and verify the resource exists.
++
+. Run `cdk orphan` with the construct path of the resource:
++
+[source,bash,subs="verbatim,attributes"]
+----
+$ cdk orphan MyStack/MyTable --unstable=orphan
+----
++
+. The command outputs a resource mapping. Save this for the import step.
++
+. Update your CDK code to use the new construct type (for example, change `Table` to `TableV2`).
++
+. Run `cdk import` with the resource mapping from the orphan output:
++
+[source,bash,subs="verbatim,attributes"]
+----
+$ cdk import MyStack --resource-mapping-inline '{"MyTable":{"TableName":"my-table"}}'
+----
++
+. After the import completes, `cdk import` detects drift and prompts you to deploy. Accept the prompt to reconcile the stack.
+
+This feature currently has the following limitations:
+
+* All construct paths must reference the same stack. Orphaning resources across multiple stacks in a single command is not supported.
+* Wildcard patterns are not supported. Paths are matched as exact prefixes.
+* This command requires version 32 of the bootstrap template, which includes the necessary IAM permissions for the deploy role.
+
+[#ref-cli-cmd-orphan-usage]
+== Usage
+
+[source,none,subs="verbatim,attributes"]
+----
+$ cdk orphan <PATHS> <options>
+----
+
+[#ref-cli-cmd-orphan-args]
+== Arguments
+
+[#ref-cli-cmd-orphan-args-paths]
+*PATHS*::
+One or more construct paths to orphan, in the format `StackName/ConstructPath`. For example, `MyStack/MyTable`. Multiple paths can be provided to orphan several resources in a single command.
++
+All paths must reference the same stack.
++
+_Type_: String
++
+_Required_: Yes
+
+[#ref-cli-cmd-orphan-options]
+== Options
+
+For a list of global options that work with all CDK CLI commands, see xref:ref-cli-cmd-options[Global options].
+
+[#ref-cli-cmd-orphan-options-help]
+`--help, -h <BOOLEAN>`::
+Show command reference information for the `cdk orphan` command.
+
+[#ref-cli-cmd-orphan-examples]
+== Examples
+
+[#ref-cli-cmd-orphan-examples-single]
+=== Orphan a single resource
+
+[source,bash,subs="verbatim,attributes"]
+----
+$ cdk orphan MyStack/MyTable --unstable=orphan
+----
+
+[#ref-cli-cmd-orphan-examples-multiple]
+=== Orphan multiple resources
+
+[source,bash,subs="verbatim,attributes"]
+----
+$ cdk orphan MyStack/MyTable MyStack/MyBucket --unstable=orphan
+----
+
+[#ref-cli-cmd-orphan-examples-yes]
+=== Skip confirmation prompt
+
+[source,bash,subs="verbatim,attributes"]
+----
+$ cdk orphan MyStack/MyTable --unstable=orphan --yes
+----

--- a/v2/guide/ref-cli-cmd.adoc
+++ b/v2/guide/ref-cli-cmd.adoc
@@ -91,6 +91,10 @@ Migrate {aws} resources, {aws} CloudFormation stacks, and {aws} CloudFormation t
 `xref:ref-cli-cmd-notices[notices]`::
 Display notices for your CDK application.
 
+[#ref-cli-cmd-commands-orphan]
+`xref:ref-cli-cmd-orphan[orphan]`::
+Safely detach resources from a CloudFormation stack without deleting them.
+
 [#ref-cli-cmd-commands-publish-assets]
 `xref:ref-cli-cmd-publish-assets[publish-assets]`::
 Publish assets for the specified CDK stack to their respective destinations without performing a deployment.
@@ -397,6 +401,8 @@ include::ref-cli-cmd-metadata.adoc[leveloffset=+1]
 include::ref-cli-cmd-migrate.adoc[leveloffset=+1]
 
 include::ref-cli-cmd-notices.adoc[leveloffset=+1]
+
+include::ref-cli-cmd-orphan.adoc[leveloffset=+1]
 
 include::ref-cli-cmd-publish-assets.adoc[leveloffset=+1]
 


### PR DESCRIPTION
## Description
  
  ### Documentation Change Type:
  
  - [ ] Typo/grammar fix
  - [ ] Clarification or minor improvement
  - [ ] New example or code snippet
  - [X] New section or topic
  - [ ] Major restructuring or enhancement
  
  ### Affected Documentation Page(s):
  
  - v2/guide/ref-cli-cmd-orphan.adoc (new file)
  - v2/guide/ref-cli-cmd.adoc (added orphan to command listing and includes)
  
  ### Description of Changes
  
  Adds CLI reference documentation for the new cdk orphan command, which was merged in aws-cdk-cli#1399 (https://github.com/aws/aws-cdk-cli/pull/1399). The new page follows the same structure as existing CLI command references (ref-cli-cmd-import.adoc, ref-cli-cmd-refactor.adoc) and includes:
  
  - Command description and use cases
  - How the three-step orphan process works (resolve, decouple, remove)
  - Step-by-step walkthrough for orphaning and re-importing a resource
  - Usage, arguments, and options
  - Examples for single resource, multiple resources, and skipping confirmation
  - Current limitations (single stack, no wildcards, bootstrap v32)
  
  The command listing in ref-cli-cmd.adoc is updated with the orphan entry in alphabetical order.
  
 ## Motivation and Context
  
The cdk orphan command enables users to safely detach stateful resources from a CloudFormation stack without deleting them. This is needed when migrating between construct types (for example, DynamoDB Table to TableV2) where CloudFormation would otherwise replace the resource, causing data loss. The command is currently in developer preview behind --unstable=orphan.
  
### How Has This Been Validated?
  
  - Previewed using the VS Code AsciiDoc extension
  - Verified structure and formatting matches existing CLI reference pages (ref-cli-cmd-import.adoc, ref-cli-cmd-refactor.adoc)
  - Confirmed all xref links reference valid page IDs
  
### Screenshots (if appropriate)
  
  N/A
  
  Checklist
  
  - [X] My changes follow the AsciiDoc syntax (./CONTRIBUTING.md#asciidoc-syntax-reference) guidelines
  - [X] I have previewed my changes using GitHub's preview or a local AsciiDoc renderer
  - [X] My changes maintain consistent formatting with the rest of the documentation
  - [X] I have checked that all links work correctly
  
### Additional Information
The cdk orphan command was introduced in aws-cdk-cli#1399 (https://github.com/aws/aws-cdk-cli/pull/1399). It complements the existing cdk import and cdk refactor commands. Use cdk refactor when renaming or moving resources without changing the construct type. Use cdk orphan when the construct type or CloudFormation resource type needs to change.