### PR TITLE
(fix): Correct cloud assembly specification url

### DIFF
--- a/v2/guide/chapter-deploy.adoc
+++ b/v2/guide/chapter-deploy.adoc
@@ -175,7 +175,7 @@ $ cdk --app <./my-cloud-assembly> ls
 +
 The call to `app.synth()` is what tells the {aws} CDK to synthesize a cloud assembly from an app. Typically you don't interact directly with cloud assemblies. They are files that include everything needed to deploy your app to a cloud environment. For example, it includes an {aws} CloudFormation template for each stack in your app. It also includes a copy of any file assets or Docker images that you reference in your app.
 +
-See the https://github.com/aws/aws-cdk/blob/master/design/cloud-assembly.md[cloud assembly specification] for details on how cloud assemblies are formatted.
+See the https://github.com/aws/aws-cdk-cli/blob/main/packages/%40aws-cdk/cloud-assembly-schema/README.md[cloud assembly specification] for details on how cloud assemblies are formatted.
 +
 To interact with the cloud assembly that your {aws} CDK app creates, you typically use the {aws} CDK CLI. However, any tool that can read the cloud assembly format can be used to deploy your app.
 


### PR DESCRIPTION
Update the cloud assembly specification url to point to the current location.

## Description

**Documentation Change Type:**

- [ ] Typo/grammar fix
- [x] Clarification or minor improvement
- [ ] New example or code snippet
- [ ] New section or topic
- [ ] Major restructuring or enhancement

**Affected Documentation Page(s):**
- https://docs.aws.amazon.com/cdk/v2/guide/deploy.html

## Description of Changes
The current deploy guide points to a v1 design doc, which only contains a link to the README.md in the CDK v1 Cloud Assembly Schema package. The update URL goes directly to the CDK v2 Cloud Assemble Schema package README

## Motivation and Context
The CDK v2 documentation -> CDK v2 Package

## How Has This Been Validated?
Yes

## Screenshots (if appropriate)
<!-- Include screenshots of the documentation before and after your changes -->

## Checklist

- [x] My changes follow the [AsciiDoc syntax](./CONTRIBUTING.md#asciidoc-syntax-reference) guidelines
- [x] I have previewed my changes using GitHub's preview or a local AsciiDoc renderer
- [x] My changes maintain consistent formatting with the rest of the documentation
- [x] I have checked that all links work correctly

## Additional Information
<!-- Any additional information or context that might be helpful for reviewers -->
